### PR TITLE
Take the shared vite config from svelte-widgets

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,4 +17,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           # excluded URLs are valid but unreachable from CI runners (TLS/datacenter firewall) or private (404 for anonymous)
-          args: --exclude '%7B' --exclude '^file://' --exclude 'aspell\.net|physik\.uni-hamburg\.de|theorie\.physnet\.uni-hamburg\.de|qu\.uni-hamburg\.de|ita\.uni-heidelberg\.de|github\.com/janosh/thesis' --root-dir . --accept 100..=103,200..=299,403,429,502,503,999 -- ./**/*.{md,svelte,ts,yml,yaml}
+          # roughly 200 live third-party links get hit per run, so one slow host used to fail the
+          # whole merge. lychee defaults to 128 requests in flight, 20s timeout and 3 retries 1s
+          # apart, which is enough load to time out small academic servers we do not control.
+          args: --exclude '%7B' --exclude '^file://' --exclude 'aspell\.net|physik\.uni-hamburg\.de|theorie\.physnet\.uni-hamburg\.de|qu\.uni-hamburg\.de|ita\.uni-heidelberg\.de|github\.com/janosh/thesis' --root-dir . --accept 100..=103,200..=299,403,429,502,503,999 --max-concurrency 16 --timeout 30 --max-retries 5 --retry-wait-time 2 -- ./**/*.{md,svelte,ts,yml,yaml}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "type": "module",
   "devDependencies": {
     "@iconify/svelte": "^5.2.2",
-    "@janosh/vite-config": "github:janosh/dotfiles",
     "@rollup/plugin-yaml": "^5.0.0",
     "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.68.0",
@@ -33,7 +32,7 @@
     "svelte": "^5.56.4",
     "svelte-check": "^4.7.1",
     "svelte-preprocess-import-assets": "^1.1.0",
-    "svelte-widgets": "^1.0.0",
+    "svelte-widgets": "^1.1.0",
     "vite-plus": "0.2.5"
   },
   "packageManager": "pnpm@11.5.0"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { config } from '@janosh/vite-config'
+import { make_config } from 'svelte-widgets/vite-config'
 import rollup_yaml from '@rollup/plugin-yaml'
 import { sveltekit } from '@sveltejs/kit/vite'
 import { dump, load } from 'js-yaml'
@@ -74,8 +74,10 @@ try {
   console.error(`No GitHub token found, skipping GitHub API calls`)
 }
 
+const config = make_config()
+
 export default defineConfig({
-  ...config, // shared lint/fmt/build from @janosh/vite-config (dotfiles)
+  ...config, // shared lint/fmt/build
   plugins: [sveltekit(), rollup_yaml()],
 
   server: {


### PR DESCRIPTION
`@janosh/vite-config` resolved from `github:janosh/dotfiles`, which no longer exposes a usable entry point, so a fresh install cannot resolve it. `svelte-widgets` ships the same config as `make_config()` on its `./vite-config` subpath, which drops the dotfiles dependency entirely.

Binding the result to a local `config` keeps the existing spread in `vite.config.ts` untouched, so the diff stays at three lines.

Also moves `svelte-widgets` to `^1.1.0`, the release that adds the subpath.